### PR TITLE
Support recent Opera and alternate UA strings

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -29,13 +29,30 @@ func newLex(s string) *lex {
 	return &lex{s, 0}
 }
 
+// Returns true iff current position matches input string
+func (l *lex) matchNoConsume(m string) bool {
+	return strings.HasPrefix(l.s[l.p:], m)
+}
+
+// If current position matches input string, consumes it and returns true (else false)
 func (l *lex) match(m string) bool {
-	if !strings.HasPrefix(l.s[l.p:], m) {
+	if !l.matchNoConsume(m) {
 		return false
 	}
 
 	l.p += len(m)
 	return true
+}
+
+// Consumes first provided string that matches the current position;
+// returns true on finding any match, false otherwise
+func (l *lex) matchFirst(args ...string) bool {
+	for _, m := range args {
+		if l.match(m) {
+			return true
+		}
+	}
+	return false
 }
 
 func (l *lex) span(m string) (string, bool) {

--- a/lex_test.go
+++ b/lex_test.go
@@ -42,24 +42,34 @@ func (l lex) assertLex(t *testing.T, success, expectSuccess bool, output, expect
 func TestSpans(t *testing.T) {
 	testLex := newLex("☕Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
 
-	// quick test of match:
+	// quick test of match functions
 	if testLex.match("Mozilla") {
 		t.Fatalf("Matched non-starting string!")
+	}
+	if !testLex.matchNoConsume("☕M") {
+		t.Fatalf("failed to match unicode start")
 	}
 	if !testLex.match("☕M") {
 		t.Fatalf("failed to match unicode start")
 	}
+	// (The first span test verifies that matchFirst consumed "oz", not "ozilla")
+	if !testLex.matchFirst("ill", "oz", "ozilla") {
+		t.Fatalf("failed matchFirst")
+	}
 
+	// test that all spans consume nothing on failure
 	m, ok := testLex.span("M")
-	testLex.assertLex(t, ok, false, m, "", "ozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
+	testLex.assertLex(t, ok, false, m, "", "illa/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
 	m, ok = testLex.spanAny("MZYA")
-	testLex.assertLex(t, ok, false, m, "", "ozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
+	testLex.assertLex(t, ok, false, m, "", "illa/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
 	m, ok = testLex.spanBefore(";", "(")
-	testLex.assertLex(t, ok, false, m, "", "ozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
+	testLex.assertLex(t, ok, false, m, "", "illa/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
 
+	// test normal span
 	m, ok = testLex.span(";")
-	testLex.assertLex(t, ok, true, m, "ozilla/5.0 (X11", " Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
+	testLex.assertLex(t, ok, true, m, "illa/5.0 (X11", " Linux i686; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
 
+	// test spanBefore
 	m, ok = testLex.spanBefore("8", ")")
 	testLex.assertLex(t, ok, true, m, " Linux i6", "6; rv:38.0) Gecko/20100101 這是什麼 Firefox/38.0")
 	m, ok = testLex.spanBefore("8", ")")
@@ -67,6 +77,7 @@ func TestSpans(t *testing.T) {
 	m, ok = testLex.spanBefore("8", ")")
 	testLex.assertLex(t, ok, false, m, "", ".0) Gecko/20100101 這是什麼 Firefox/38.0")
 
+	// test spanAny
 	m, ok = testLex.spanAny("☕/這什")
 	testLex.assertLex(t, ok, true, m, ".0) Gecko", "20100101 這是什麼 Firefox/38.0")
 	m, ok = testLex.spanAny("☕/這什")
@@ -74,6 +85,7 @@ func TestSpans(t *testing.T) {
 	m, ok = testLex.spanAny("☕這Q")
 	testLex.assertLex(t, ok, false, m, "", "是什麼 Firefox/38.0")
 
+	// extra test cases
 	m, ok = testLex.spanBefore("是", "Q")
 	testLex.assertLex(t, ok, true, m, "", "什麼 Firefox/38.0")
 	m, ok = testLex.span("麼")

--- a/parse_test.go
+++ b/parse_test.go
@@ -468,4 +468,55 @@ func TestOpera(t *testing.T) {
 	if !eqUA(want, got) {
 		t.Errorf("expected %+v, got %+v\n", want, got)
 	}
+
+	got = Parse(`Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; TechniSat; DigiPal ISIO HD; 2.70.0.5; 57.0-6; ); CE-HTML/1.0 (); MB_BP/1.0 (TechniSat; DigiPal ISIO HD; ); TechniSat DigiPal ISIO HD BCM3 STB; de) Presto/2.12.407 Version/12.51`)
+	want.Type = Browser
+	want.OS = "GNU/Linux"
+	want.Name = "Opera"
+	want.Version = mustParse("12.51.0")
+	want.Security = SecurityStrong
+	if !eqUA(want, got) {
+		t.Errorf("expected %+v, got %+v\n", want, got)
+	}
+
+	got = Parse(`Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; zh-tw) Opera 11.00`)
+	want.Type = Browser
+	want.OS = "Windows"
+	want.Name = "Opera"
+	want.Version = mustParse("11.0.0")
+	want.Security = SecurityUnknown
+	if !eqUA(want, got) {
+		t.Errorf("expected %+v, got %+v\n", want, got)
+	}
+
+	got = Parse(`Mozilla/5.0 (Windows NT 6.1; U; nl; rv:1.9.1.6) Gecko/20091201 Firefox/3.5.6 Opera 11.01`)
+	want.Type = Browser
+	want.OS = "Windows"
+	want.Name = "Opera"
+	want.Version = mustParse("11.1.0")
+	want.Security = SecurityStrong
+	if !eqUA(want, got) {
+		t.Errorf("expected %+v, got %+v\n", want, got)
+	}
+
+	got = Parse(`Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.52 Safari/537.36 OPR/15.0.1147.100`)
+	want.Type = Browser
+	want.OS = "Windows"
+	want.Name = "Opera"
+	want.Version = mustParse("15.0.1147")
+	want.Security = SecurityUnknown
+	if !eqUA(want, got) {
+		t.Errorf("expected %+v, got %+v\n", want, got)
+	}
+
+	got = Parse(`Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.52 Mobile Safari/537.36 OPR/15.0.1147.100`)
+	want.Type = Browser
+	want.OS = "Android"
+	want.Name = "Opera"
+	want.Version = mustParse("15.0.1147")
+	want.Security = SecurityUnknown
+	want.Mobile = true
+	if !eqUA(want, got) {
+		t.Errorf("expected %+v, got %+v\n", want, got)
+	}
 }


### PR DESCRIPTION
Because Opera isn't content with just one (or just 2 or 3, really) unusual useragent formats . . .

Jira APP-1813

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/useragent/2)
<!-- Reviewable:end -->
